### PR TITLE
Update metainfo.xml location

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -45,7 +45,7 @@ parts:
       - dconf-cli
     source: https://github.com/projecthamster/hamster.git
     plugin: waf
-    parse-info: [ usr/share/appdata/hamster.metainfo.xml ]
+    parse-info: [ usr/share/metainfo/hamster.metainfo.xml ]
 
   launcher:
     after: [ hamster ]


### PR DESCRIPTION
metainfo.xml recently moved to metainfo (since https://github.com/projecthamster/hamster/pull/517)