### PR TITLE
desktop file name changed

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -53,7 +53,7 @@ parts:
     source: snap/local
     organize:
       launcher.py: usr/bin/launcher
-      hamster.desktop: usr/share/applications/launcher.desktop
+      org.gnome.Hamster.GUI.desktop: usr/share/applications/launcher.desktop
 
 apps:
   hamster-snap:


### PR DESCRIPTION
Sorry, there have been some file names changes in hamster lately.
The `hamster.metainfo.xml` filename has not changed, 
so it should be good since snap gets informations from its content, which is up to date.
But the `hamster.desktop` line should be either changed as proposed in this PR,
or removed altogether ?
The latter seems fine, from the [snap doc](https://snapcraft.io/docs/using-external-metadata),  
> You can also link each app in your snap to specific AppStream metadata by pointing the common-id key of that app to the component id field in the AppStream metadata. 

that's already the case:
https://github.com/extraymond/hamster-snap/blob/3b1eace0c2a16b2720fa0635209c90bcbfc08b32/snap/snapcraft.yaml#L60

>Snapcraft will use the metadata of that component to get the .desktop entry file for that app.

So it should find the desktop [there](https://github.com/projecthamster/hamster/blob/fa687c505e00dd6f815428cf44862935f70822b7/data/hamster.metainfo.xml#L30).

Sorry for the perturbation, these are uncomfortable days, 
with v3.0 release approaching quickly, things are not as stable as they should.